### PR TITLE
minor fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This repository contains an implementation of Dijkstra's Algorithm in C++.
 ```
 $ git clone https://github.com/Alpaca-zip/dijkstra_algorithm.git
 ```
-### 2. Compile the program using a C++ compiler.
+### 2. Install dependencies and compile the program.
 ```
+$ sudo apt-get install -y libboost-all-dev
 $ bash build.sh
 ```
 ### 3. Run the program. 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
+#!/bin/bash
 # Tested on Ubuntu-20.04
 # Tested on Ubuntu-22.04
+
 cmake -S . -B build
 cmake --build build
 cd ./build/

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ./dijkstra.out
 dot -Tpdf graph.dot -o graph.pdf
 rm graph.dot


### PR DESCRIPTION
- Add command to the `README.md` to install `libboost-all-dev`, a package required by the program. This will streamline setup, especially for users who are missing these dependent packages.

- Add shebang(`#! /bin/bash`) to `build.sh` and `run.sh`. This makes it clear that these scripts will be executed in bash and improves compatibility.